### PR TITLE
feat(permission): use activeTab only

### DIFF
--- a/.changeset/long-glasses-kneel.md
+++ b/.changeset/long-glasses-kneel.md
@@ -1,0 +1,5 @@
+---
+"hoverscan": patch
+---
+
+Updated permissions to `activeTab` only.

--- a/package.json
+++ b/package.json
@@ -73,8 +73,8 @@
     "typescript": "5.0.4"
   },
   "manifest": {
-    "host_permissions": [
-      "https://*/*"
+    "permissions": [
+      "activeTab"
     ]
   }
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the extension's permissions to only allow `activeTab` access.

### Detailed summary
- Updated permissions to `activeTab` only.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->