### PR TITLE
fix: cannot edit on editable content

### DIFF
--- a/.changeset/smooth-pugs-pull.md
+++ b/.changeset/smooth-pugs-pull.md
@@ -1,0 +1,5 @@
+---
+"hoverscan": patch
+---
+
+Fixed selection issue on editable content

--- a/src/hooks/useMouseSelection.ts
+++ b/src/hooks/useMouseSelection.ts
@@ -11,7 +11,7 @@ export const useMouseSelection = (
 
   const onMouseUp = (e: MouseEvent) => {
     const shadowRootEl = e?.target as Element
-    if (shadowRootEl?.tagName?.toLowerCase() === root.toLowerCase()) return
+    if (!shadowRootEl || shadowRootEl?.tagName?.toLowerCase() === root.toLowerCase()) return
     const selection = window.getSelection()
     if (selection?.toString()) {
       setSelection(selection)
@@ -29,7 +29,7 @@ export const useMouseSelection = (
 
   const clearSelection = (e?: MouseEvent) => {
     const shadowRootEl = e?.target as Element
-    if (shadowRootEl?.tagName?.toLowerCase() === root.toLowerCase()) return
+    if (!shadowRootEl || shadowRootEl?.tagName?.toLowerCase() === root.toLowerCase()) return
     setSelection(null)
     if (window.getSelection) {
       if (window.getSelection()?.empty) { // Chrome


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on fixing a selection issue on editable content. 

### Detailed summary
- Added a condition to check if the target element exists before checking its tag name in the `onMouseUp` function.
- Added a condition to check if the target element exists before checking its tag name in the `clearSelection` function.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->