### PR TITLE
fix: container-overflow

### DIFF
--- a/.changeset/tall-trains-live.md
+++ b/.changeset/tall-trains-live.md
@@ -1,0 +1,5 @@
+---
+"hoverscan": patch
+---
+
+Fixed network list overflow style issue

--- a/src/components/Layout/Container.tsx
+++ b/src/components/Layout/Container.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { type VariantProps, tv } from 'tailwind-variants'
 
 const container = tv({
-  base: 'flex flex-col max-h-[300px] gap-3 -mx-4 px-4',
+  base: 'flex flex-col max-h-[300px] gap-3 -mx-4 px-4 overflow-auto',
 })
 
 type ContainerVariants = VariantProps<typeof container>


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on fixing a style issue related to network list overflow. 

### Detailed summary
- Added `overflow-auto` class to the `base` style of the `Container` component in `src/components/Layout/Container.tsx`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->